### PR TITLE
Fix wrong highlight for Chinese characters

### DIFF
--- a/source/code/scripts/components/string.js
+++ b/source/code/scripts/components/string.js
@@ -37,7 +37,8 @@ export default {
 
   findDiacritics(s) {
     if (!s) return s;
-    var rx = /[^\u0000-\u007E]/gm;
+
+    var rx = /[\u0300-\u036F]|[\u1AB0–\u1AFF]|[\u1DC0–\uDFF]|[\u20D0–\u20FF]|[\uFE20\uFE2F]/gm;
     var a = [], m;
     while (m = rx.exec(s)) {
       a.push({
@@ -181,7 +182,7 @@ export default {
   /**
    * Returns a value indicating whether the given string starts with the second
    * given string.
-   * 
+   *
    * @param {string} String to check
    * @param {string} Start value
    * @param {boolean} Case insensitive?


### PR DESCRIPTION
The original `findDiacritics` is listing all Chinese characters as diacritics. It will wrongly highlight values when searching in the UI.

The fix here is following https://en.wikipedia.org/wiki/Combining_character and use correct Diacritics ranges.