### PR TITLE
Avoid treating Chinese character as Diacritics

### DIFF
--- a/source/code/scripts/components/string.js
+++ b/source/code/scripts/components/string.js
@@ -38,13 +38,15 @@ export default {
   findDiacritics(s) {
     if (!s) return s;
 
-    var rx = /[\u0300-\u036F]|[\u1AB0–\u1AFF]|[\u1DC0–\uDFF]|[\u20D0–\u20FF]|[\uFE20\uFE2F]/gm;
+    var rx = /[^\u0000-\u007E]/gm;
     var a = [], m;
     while (m = rx.exec(s)) {
-      a.push({
-        i: m.index,
-        v: m[0]
-      });
+      if (normalize(m[0]) != m[0]){
+        a.push({
+          i: m.index,
+          v: m[0]
+        });
+      }
     }
     return a;
   },

--- a/source/code/tests/kingtable.html.builder.spec.js
+++ b/source/code/tests/kingtable.html.builder.spec.js
@@ -122,4 +122,23 @@ describe("KingTableHtmlBuilder", () => {
     var html = a.highlight(text, pattern);
     expect(html).toEqual(`<span class="kt-search-highlight">Bar</span>łysławłłł`);
   })
+
+  it("must support diacritics, properly highlight Chinese characters", () => {
+    var a = new KingTableHtmlBuilder();
+    var text = "2017年12月31日";
+    var pattern = /日/gim;
+
+    var html = a.highlight(text, pattern);
+    expect(html).toEqual(`2017年12月31<span class="kt-search-highlight">日</span>`);
+  })
+
+  it("must support diacritics, properly highlight non-Chinese characters in Chinese characters string", () => {
+    var a = new KingTableHtmlBuilder();
+    var text = "2017年12月31日";
+    var pattern = /12/gim;
+
+    var html = a.highlight(text, pattern);
+    expect(html).toEqual(`2017年<span class="kt-search-highlight">12</span>月31日`);
+  })
+
 });

--- a/source/code/tests/string.spec.js
+++ b/source/code/tests/string.spec.js
@@ -150,25 +150,33 @@ Cat`
     var diacritics = [
       {i: 0, v: 'Ż'}, {i: 10, v: 'ę'}, {i: 14, v: 'ą'}, {i: 15, v: 'ż'}
     ];
-    
+
     expect(S.restoreDiacritics(a, diacritics)).toEqual("Żelazowskięasdąż")
   })
 
   it("must allow to restore diacritics in strings, with offset", () => {
     var a = "Henrik Nordvargr Björkk"
     var diacritics = [{i: 19, v: "ö"}];
-    
+
     var portion = "Bjorkk";
     var offset = a.indexOf("B");
     expect(S.restoreDiacritics(portion, diacritics, offset)).toEqual("Björkk")
   })
 
+  it("must not find Chinese characters when find diacritics in strings", () => {
+    var a = "2017年12月31日"
+    var diacritics = S.findDiacritics(a)
+
+    expect(diacritics).toEqual([])
+  })
+
   it("must allow to find diacritics in strings", () => {
     var a = "Żelazowskięasdąż"
     var diacritics = S.findDiacritics(a)
-    
+
     expect(diacritics).toEqual([
       {i: 0, v: 'Ż'}, {i: 10, v: 'ę'}, {i: 14, v: 'ą'}, {i: 15, v: 'ż'}
     ])
   })
+
 });


### PR DESCRIPTION
Chinese characters were treated as diacritics which would return wrongly highlighted string when searching Chinese character within string.

For example, search `日` within `2017年12月31日` would return `2017年12月31<span class="kt-search-highlight">日年日</span>`.

This change utilize the existing `normalize` function to validate the found string is a valid diacritics.